### PR TITLE
Set primary text color to brand color

### DIFF
--- a/src/components/Slider/Slider.component.js
+++ b/src/components/Slider/Slider.component.js
@@ -29,7 +29,7 @@ const Slider = ({ value, valueLabel, minValue, maxValue, onChange }) => {
       />
       <label
         htmlFor="myRange"
-        className="text-accent1 font-bold absolute left-px -top-2"
+        className="text-primary font-bold absolute left-px -top-2"
         style={{
           transform: `translateX(${value * step}px)`,
         }}

--- a/src/components/Typography/Heading/Heading.component.js
+++ b/src/components/Typography/Heading/Heading.component.js
@@ -42,12 +42,8 @@ const getTextColor = (color) => {
   switch (color) {
     case 'primary':
       return 'text-primary';
-    case 'secondary':
-      return 'text-secondary';
-    case 'accent1':
-      return 'text-accent1';
     default:
-      return 'text-primary';
+      return 'text-default';
   }
 };
 
@@ -72,12 +68,11 @@ const Heading = ({ children, onClick, level, color, className }) => {
 Heading.propTypes = {
   ...TypographyBase.propTypes,
   level: PropTypes.oneOf([1, 2, 3, 4]),
-  color: PropTypes.oneOf(['primary', 'secondary', 'accent1']),
+  color: PropTypes.oneOf(['primary', 'default']),
 };
 
 Heading.defaultProps = {
   level: 1,
-  color: 'primary',
 };
 
 export default Heading;

--- a/src/components/Typography/Heading/Heading.stories.js
+++ b/src/components/Typography/Heading/Heading.stories.js
@@ -13,7 +13,7 @@ export default {
       control: { type: 'radio', options: [1, 2, 3, 4] },
     },
     color: {
-      control: { type: 'radio', options: ['primary', 'secondary', 'accent1'] },
+      control: { type: 'radio', options: ['primary', 'default'] },
     },
   },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,9 +19,8 @@ module.exports = {
         buttonSecondary: '#C9C9C9',
       },
       textColor: {
-        primary: '#fff',
-        secondary: '#272727',
-        accent1: '#3AC1C8',
+        primary: '#3AC1C8',
+        default: '#FFF',
       },
       borderWidth: {
         3: '3px',


### PR DESCRIPTION
We've managed to upset the designer again.

The primary color (ie key brand color) should be used when something needs to be emphasized: e.g. CTA, main heading etc.

The rest of the colors should be quite neutral - so I've renamed `text-secondary` to `text-default`. This is used in non-primary situations e.g. normal paragraphs and non-highligthed headings.

I get that **primary** sounds like it's the main color used (quantity) but that's not how designers see **primary** colors (yes, there can be more of them). 

I suggest `default` as default :) for text, as the value of default will depend on the background (e.g. light on dark and vice versa).

Makes sense? 
