### PR TITLE
Listbox boolean value and position fix

### DIFF
--- a/src/components/Listbox/Listbox.component.js
+++ b/src/components/Listbox/Listbox.component.js
@@ -89,9 +89,12 @@ const ListBox = ({
             <HeadlessListBox.Option
               key={option.value}
               value={option.value}
-              className="cursor-pointer hover:bg-hover text-left px-4 py-2 rounded-lg "
             >
-              {option.label}
+              {({ active, selected }) => (
+                <li className={`cursor-pointer hover:bg-hover text-left px-4 py-2 rounded-lg  ${active || selected ? 'bg-hover' : null}`}>
+                  {option.label}
+                </li>
+              )}
             </HeadlessListBox.Option>
           ))
         ) : emptyHeader ? (


### PR DESCRIPTION
### Listbox fixes

- Listbox boolean value fix
  Problem: Listbox was not accepting the boolean false value.
  Solution: Check is added if the value selected is boolean accept it.
    
- Listbox position fix
  Problem: Listbox was a display block when we open the dropdown it pushes all content down that is under the dropdown
  Solution: Make the dropdown position absolute relative to the dropdown button
   
- Listbox arrow selection fix
  Problem: Listbox li not highlighted when selecting with arrow keys
  Solution: Added a check highlighted if selecting an item using arrow keys and the active item selected. 