### PR TITLE
fix button text leading

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_on_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@master
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: npm install
+      - name: Compute GH short sha
+        run: echo "SHORT_SHA=`git rev-parse --short HEAD`" >> $GITHUB_ENV
+      - name: Set npm to CI mode
+        run: npm ci
+      - name: Prerelease tag
+        run: npm version --no-git-tag-version prerelease --preid=${SHORT_SHA}
+      - run: npm run build
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Build Artifacts
+          retention-days: 7
+          path: '*.tgz'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,15 +12,18 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 14
+      - name: Set npm to CI mode
+        run: npm ci
       - name: Install dependencies
         run: npm install
       - name: Compute GH short sha
         run: echo "SHORT_SHA=`git rev-parse --short HEAD`" >> $GITHUB_ENV
-      - name: Set npm to CI mode
-        run: npm ci
       - name: Prerelease tag
         run: npm version --no-git-tag-version prerelease --preid=${SHORT_SHA}
-      - run: npm run build
+      - name: Build 
+        run: npm run build
+      - name: Package as .tgz
+        run: npm pack
       - name: Archive build artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/src/components/Button/Button.component.js
+++ b/src/components/Button/Button.component.js
@@ -119,7 +119,7 @@ const Button = ({
   return (
     <button
       type={type}
-      className={`rounded-md font-bold font-sans leading-none ${sizeStyle} ${className} ${getPointerStyle(
+      className={`rounded-md font-bold font-sans ${sizeStyle} ${className} ${getPointerStyle(
         disabled,
       )} ${getBorderWidth(variant, appearance)} ${getBorderColors(
         variant,
@@ -141,7 +141,7 @@ const Button = ({
       disabled={disabled}
       form={form}
     >
-      {label}
+      <div className='leading-none'>{label}</div>
     </button>
   );
 };


### PR DESCRIPTION
Fix button text centering issue. 

This is done by wrapping the `leading-none` in a div, as the style would otherwise be overwritten in other tailwind projects e.g. cinead-tradedesk uncentering the button text.

Furthermore the package is now build as a tgz to be downloaded on PRs and pushes for easier local testing between releases.

Changes:
- Wrap button text in div
- Build on GH actions.
- Add packaging step.
