### PR TITLE
refactor: remove screens from poster card component in cine ui

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,9 +17,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           scope: '@cinemataztic'
+
+      - run: npm install -g npm@latest
 
       - run: npm ci --legacy-peer-deps
  

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,8 +21,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@cinemataztic'
 
-      - run: npm install -g npm@latest
-
       - run: npm ci --legacy-peer-deps
  
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/cine-ui",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/cine-ui",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/cine-ui",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/cine-ui",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/cine-ui",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/cine-ui",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/cine-ui",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Cinemataztic React UI component library.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/cine-ui",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Cinemataztic React UI component library.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/cine-ui",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Cinemataztic React UI component library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Carousel/PosterCard.component.js
+++ b/src/components/Carousel/PosterCard.component.js
@@ -46,7 +46,7 @@ const PosterCard = ({ movie, renderActions }) => {
       <div className='mt-2 text-center'>
         <p className='text-lg font-semibold text-white truncate'>{movie.title}</p>
         <p className='text-sm font-normal mt-0.5' style={{ color: 'var(--movie-card-meta-color, #7D7D7D)' }}>{movie.distributor}</p>
-        {!!movie.screens && <p className='text-sm font-normal' style={{ color: 'var(--movie-card-meta-color, #7D7D7D)' }}>{movie.screens} Screens</p>}
+        {!!movie.screens && <p className='text-sm font-normal' style={{ color: 'var(--movie-card-meta-color, #7D7D7D)' }}>{movie.screens} {movie.screens === 1 ? 'Screen' : 'Screens'}</p>}
         {renderActions && (
           <div className='flex justify-center mt-2'>
             {renderActions()}

--- a/src/components/Carousel/PosterCard.component.js
+++ b/src/components/Carousel/PosterCard.component.js
@@ -46,7 +46,7 @@ const PosterCard = ({ movie, renderActions }) => {
       <div className='mt-2 text-center'>
         <p className='text-lg font-semibold text-white truncate'>{movie.title}</p>
         <p className='text-sm font-normal mt-0.5' style={{ color: 'var(--movie-card-meta-color, #7D7D7D)' }}>{movie.distributor}</p>
-        <p className='text-sm font-normal' style={{ color: 'var(--movie-card-meta-color, #7D7D7D)' }}>{movie.screens} Screens</p>
+        {!!movie.screens && <p className='text-sm font-normal' style={{ color: 'var(--movie-card-meta-color, #7D7D7D)' }}>{movie.screens} Screens</p>}
         {renderActions && (
           <div className='flex justify-center mt-2'>
             {renderActions()}


### PR DESCRIPTION
**What is the intent of this change?**                                                                                             
                                                                                                                                     
  This PR removes the screens information from the poster card component.                              
   
  ## ✅ First-Time Right Checklist

  - [x] **Scope & Impact:** Affects the poster card component, makes the screens label optional.
  - [x] **Logical Consistency:** Being optional they can be disabled and enabled based on requirements. Will affect the movie picker in tradedesk.
  - [x] **Bot Warnings Addressed:** All high priority and medium priority warnings are addressed.
  - [x] **Relay Ready:** This description provides full context for team to understand the new feature.