### PR TITLE
feat: display placeholder for poster card in case of error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cinemataztic/cine-ui",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cinemataztic/cine-ui",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cinemataztic/cine-ui",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Cinemataztic React UI component library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Carousel/PosterCard.component.js
+++ b/src/components/Carousel/PosterCard.component.js
@@ -42,11 +42,11 @@ const PosterCard = ({ movie, renderActions }) => {
           />
         ) : (
           <div style={{ width: '100%', height: '100%', background: 'var(--movie-card-bg, #444)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 8 }}>
-            <svg width='48' height='48' viewBox='0 0 24 24' fill='none' style={{ opacity: 0.35, color: 'var(--carousel-accent, #3dd6c8)' }}>
+            <svg aria-hidden='true' width='48' height='48' viewBox='0 0 24 24' fill='none' style={{ opacity: 0.35, color: 'var(--carousel-accent, #3dd6c8)' }}>
               <rect x='2' y='4' width='20' height='16' rx='2' stroke='currentColor' strokeWidth='1.5' />
               <path d='M2 8h20M2 16h20M7 4v4M7 16v4M12 4v16M17 4v4M17 16v4' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round' />
             </svg>
-            <span style={{ color: 'rgba(255,255,255,0.4)', fontSize: 12, textAlign: 'center', padding: '0 8px', lineHeight: 1.3 }}>{movie.title}</span>
+            <span style={{ color: 'rgba(255,255,255,0.4)', fontSize: 12, textAlign: 'center', padding: '0 8px', lineHeight: 1.3, display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>{movie.title}</span>
           </div>
         )}
       </div>

--- a/src/components/Carousel/PosterCard.component.js
+++ b/src/components/Carousel/PosterCard.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 const PosterCard = ({ movie, renderActions }) => {
   const [hovered, setHovered] = useState(false);
+  const [imgError, setImgError] = useState(false);
 
   return (
     <div
@@ -24,11 +25,12 @@ const PosterCard = ({ movie, renderActions }) => {
         background: 'var(--movie-card-bg, #444)',
         flexShrink: 0,
       }}>
-        {movie.posterUrl ? (
+        {movie.posterUrl && !imgError ? (
           <img
             src={movie.posterUrl}
             alt={movie.title}
             draggable={false}
+            onError={() => setImgError(true)}
             style={{
               width: '100%',
               height: '100%',
@@ -39,7 +41,13 @@ const PosterCard = ({ movie, renderActions }) => {
             }}
           />
         ) : (
-          <div style={{ width: '100%', height: '100%', background: 'var(--movie-card-bg, #444)' }} />
+          <div style={{ width: '100%', height: '100%', background: 'var(--movie-card-bg, #444)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 8 }}>
+            <svg width='48' height='48' viewBox='0 0 24 24' fill='none' style={{ opacity: 0.35, color: 'var(--carousel-accent, #3dd6c8)' }}>
+              <rect x='2' y='4' width='20' height='16' rx='2' stroke='currentColor' strokeWidth='1.5' />
+              <path d='M2 8h20M2 16h20M7 4v4M7 16v4M12 4v16M17 4v4M17 16v4' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round' />
+            </svg>
+            <span style={{ color: 'rgba(255,255,255,0.4)', fontSize: 12, textAlign: 'center', padding: '0 8px', lineHeight: 1.3 }}>{movie.title}</span>
+          </div>
         )}
       </div>
 

--- a/src/components/Carousel/PosterCard.component.js
+++ b/src/components/Carousel/PosterCard.component.js
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 
 const PosterCard = ({ movie, renderActions }) => {
   const [hovered, setHovered] = useState(false);
-  const [imgError, setImgError] = useState(false);
+  const [imgFallbackLevel, setImgFallbackLevel] = useState(0);
+
+  const FALLBACK_URL = 'https://images.cinemataztic.com/_global/NoPosterFallback-EN.png';
+  const imgSrc = imgFallbackLevel === 0 ? movie.posterUrl : FALLBACK_URL;
 
   return (
     <div
@@ -25,12 +28,12 @@ const PosterCard = ({ movie, renderActions }) => {
         background: 'var(--movie-card-bg, #444)',
         flexShrink: 0,
       }}>
-        {movie.posterUrl && !imgError ? (
+        {imgSrc && imgFallbackLevel < 2 ? (
           <img
-            src={movie.posterUrl}
+            src={imgSrc}
             alt={movie.title}
             draggable={false}
-            onError={() => setImgError(true)}
+            onError={() => setImgFallbackLevel(l => l + 1)}
             style={{
               width: '100%',
               height: '100%',


### PR DESCRIPTION
**What is the intent of this change?**                                                                                             
                                                                                                                                     
  This PR adds placeholder image if the poster card component fails to render poster url.    

  If poster url from the api throws error, display this poster as fallback.
  
  <img width="1560" height="614" alt="image" src="https://github.com/user-attachments/assets/eb38efa9-e14f-4c9f-bcc5-1642d5f84b6c" />
  
  
  If fallback poster also fails to load, display this placeholder image.
  
<img width="1117" height="488" alt="image" src="https://github.com/user-attachments/assets/830c5fb6-83ed-4b18-a61d-031677f965d0" />
                          
   
  ## ✅ First-Time Right Checklist

  - [x] **Scope & Impact:** Affects the poster card component, makes the screens label optional.
  - [x] **Logical Consistency:** Being optional they can be disabled and enabled based on requirements. Will affect the movie picker in tradedesk.
  - [x] **Bot Warnings Addressed:** All high priority and medium priority warnings are addressed.
  - [x] **Relay Ready:** This description provides full context for team to understand the new feature.